### PR TITLE
WIP: Closes #21: Safer fields (escaping fields in xhtm)

### DIFF
--- a/htm.js
+++ b/htm.js
@@ -1,5 +1,8 @@
 const FIELD = '\ue000', QUOTES = '\ue001'
 
+const map = { '&':'amp', '<':'lt', '>':'gt', '"':'quot', "'":'apos' }
+const escape = str => String(str).replace(/[&<>"']/g, s => `&${map[s]};`)
+
 export default function htm (statics) {
   let h = this, prev = 0, current = [null], field = 0, args, name, value, quotes = [], quote = 0, last, level = 0
 
@@ -13,7 +16,9 @@ export default function htm (statics) {
     str.replace(/\ue000/g, (match, idx) => {
       if (idx) parts.push(str.slice(i, idx))
       i = idx + 1
-      return parts.push(arguments[++field])
+      let fieldContents = arguments[++field]
+      fieldContents = typeof fieldContents === 'string' ? escape(fieldContents) : fieldContents
+      return parts.push(fieldContents)
     })
     if (i < str.length) parts.push(str.slice(i))
     return parts.length > 1 ? parts : parts[0]

--- a/test/html.js
+++ b/test/html.js
@@ -162,3 +162,28 @@ t('html: directives', t => {
   t.is(html`<!-- comment -->`, undefined)
   t.is(html`<!--[if expression]> HTML <![endif]-->`, undefined)
 })
+
+t('safer fields', t => {
+	t.is(html`
+		<script>alert('This is fine')</script>
+		<style>.soIsThis { font-size: 3em; }</style>
+		${'<script>alert("But it avoids this injection attempt")</script>'}
+		<pre><code>${'<p>And it auto-escapes code snippets.</p>'}</code></pre>
+	`,
+	[
+	  { tag: 'script', props: null, children: [ "alert('This is fine')" ] },
+	  {
+	    tag: 'style',
+	    props: null,
+	    children: [ '.soIsThis { font-size: 3em; }' ]
+	  },
+	  '&lt;script&gt;alert(&quot;But it avoids this injection attempt&quot;)&lt;/script&gt;',
+		{
+			tag: 'pre',
+			props: null,
+			children: [
+				{tag: 'code', props: null, children: ['&lt;p&gt;And it auto-escapes code snippets.&lt;/p&gt;']}
+			]
+		}
+	])
+})


### PR DESCRIPTION
Escapes fields (interpolated strings)

See #21 for a more detailed explanation of the reasoning behind it.